### PR TITLE
fix bug

### DIFF
--- a/src/main/java/ppn/bungeecord/BungeePlayerNotify.java
+++ b/src/main/java/ppn/bungeecord/BungeePlayerNotify.java
@@ -50,6 +50,7 @@ public class BungeePlayerNotify extends Plugin {
         }
 
         saveDefaultConfig();
+        loadConfig();
         config.addDefault("join_message", "%player% has joined the network (Logged in server: %server%) at %time%",
                 "Network Join Message\nThis message is displayed when a player joins the network.\nPlaceholders available: %player%, %lp_prefix%, %lp_suffix%, %server%, %time%.");
 


### PR DESCRIPTION
fix the bug
```
[19:44:08] [main/WARN]: Exception encountered when loading plugin: ProxyPlayerNotify
java.lang.NullPointerException: Cannot invoke "ppn.ConfigManager.addDefault(String, Object, String)" because "this.config" is null
	at ppn.bungeecord.BungeePlayerNotify.onEnable(BungeePlayerNotify.java:53) ~[?:?]
	at net.md_5.bungee.api.plugin.PluginManager.enablePlugins(PluginManager.java:316) ~[waterfall.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:9ab9e2b:582]
	at net.md_5.bungee.BungeeCord.start(BungeeCord.java:302) ~[waterfall.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:9ab9e2b:582]
	at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:68) ~[waterfall.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:9ab9e2b:582]
	at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15) ~[waterfall.jar:git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:9ab9e2b:582]
```